### PR TITLE
Add sentry to gitpoap-bot

### DIFF
--- a/environment.d.ts
+++ b/environment.d.ts
@@ -1,0 +1,17 @@
+declare global {
+  namespace NodeJS {
+    interface ProcessEnv {
+      NODE_ENV: 'development' | 'production';
+      WEBHOOK_PROXY_URL: string;
+      APP_ID: string;
+      PRIVATE_KEY: string;
+      WEBHOOK_SECRET: string;
+      GITHUB_CLIENT_ID: string;
+      GITHUB_CLIENT_SECRET: string;
+      API_URL: string;
+      SENTRY_DSN: string;
+    }
+  }
+}
+
+export {};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,14 @@
 import { Context, Probot } from 'probot';
 import { fetch } from 'cross-fetch';
+import * as Sentry from '@sentry/node';
+
+/* @probot/pino automatically picks up SENTRY_DSN from .env */
+Sentry.init({
+  environment: process.env.NODE_ENV,
+  /* Do not send errors to sentry if app is in development mode */
+  enabled: process.env.NODE_ENV !== 'development',
+  tracesSampleRate: 1.0,
+});
 
 export = (app: Probot) => {
   /* Eventually turn into pull_request.merged */


### PR DESCRIPTION
Summary: 
- Add `environment.d.ts` to define what environment variables the app expects. 
- Configure sentry in `index.ts`