### PR TITLE
Skip sending creation API request if user is a bot

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -56,6 +56,14 @@ export default (app: Probot) => {
       `Handling newly merged PR: https://github.com/${owner}/${repo}/${pullRequestNumber}`,
     );
 
+    // Skip claims creation API request if the creator of the PR is a bot
+    if (context.payload.pull_request.user.type === 'Bot') {
+      context.log.info(
+        `Skipping creating claims for PR made by bot "${context.payload.pull_request.user.login}"`
+      );
+      return;
+    }
+
     const octokit = await app.auth(); // Not passing an id returns a JWT-authenticated client
     const jwt = (await octokit.auth({ type: 'app' })) as { token: string };
 


### PR DESCRIPTION
Fixes: https://github.com/gitpoap/gitpoap-bot/issues/11

Context payload reference: https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#webhook-payload-example-34