### PR TITLE
Feat: Create GitPOAP claims on PR/issue comments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,9 @@
-# The ID of your GitHub App
-APP_ID=
-WEBHOOK_SECRET=development
-
-# Use `trace` to get verbose logging or `info` to show less
-LOG_LEVEL=debug
-
-# Go to https://smee.io/new set this to the URL that you are redirected to.
+NODE_ENV=
 WEBHOOK_PROXY_URL=
+APP_ID=
+PRIVATE_KEY=""
+WEBHOOK_SECRET=
+GITHUB_CLIENT_ID=
+GITHUB_CLIENT_SECRET=
+API_URL=
+SENTRY_DSN=

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -14,6 +14,7 @@ Sentry.init({
 type BotClaimData = {
   id: number;
   gitPOAP: { id: number; poapEventId: number; threshold: number };
+  user: { githubHandle: string },
   name: string;
   imageUrl: string;
   description: string;
@@ -37,6 +38,31 @@ function generateComment(claims: BotClaimData[]): string {
 
   comment +=
     '\n\nHead on over to [GitPOAP.io](https://www.gitpoap.io) and connect your GitHub account to mint!';
+
+  return comment;
+}
+
+function generateIssueComment(claims: BotClaimData[]): string {
+  let qualifier: string;
+  if (claims.length > 1) {
+    qualifier = `some GitPOAPs`;
+  } else {
+    qualifier = `a GitPOAP`;
+  }
+
+  const receivers = claims.map(claim => claim.user.githubHandle);
+  const uniqueReceivers = Array.from(new Set(receivers));
+  const receiversTag = uniqueReceivers.reduce((acc, ele) => acc + `@${ele} `, "");
+  let comment = `Congrats, ${receiversTag}! You've earned ${qualifier} for your contribution!\n`;
+
+  for (const claim of claims) {
+    comment += `
+[**${claim.name}**](https://www.gitpoap.io/gp/${claim.gitPOAP.id}):
+<img alt="${claim.name} GitPOAP Badge" src="${claim.imageUrl}" height="200px">`;
+  }
+
+  comment +=
+    '\n\nHead on over to [GitPOAP.io](https://www.gitpoap.io) and connect your GitHub account to mint if you haven’t already!';
 
   return comment;
 }
@@ -104,17 +130,94 @@ export default (app: Probot) => {
     context.log.info(`Posted comment about new claims: ${result.data.html_url}`);
   });
 
-  // Useful for testing purposes:
-  //
-  //  app.on('pull_request.closed', async (context) => {
-  //    const pullRequestNum = context.payload.pull_request.number;
-  //    const issueComment = context.issue({
-  //      body: `Thanks for CLOSING PR #${pullRequestNum}!`,
-  //    });
-  //
-  //    context.log.info(context.payload.repository.owner);
-  //
-  //    context.log.info('PR HAS BEEN CLOSED');
-  //    await context.octokit.issues.createComment(issueComment);
-  //  });
+  app.on("issue_comment.created", async (context: Context<'issue_comment.created'>) => {
+    const repo = context.payload.repository.name;
+    const owner = context.payload.repository.owner.login;
+    const organization = context.payload.organization?.login ?? "";
+    const sender = context.payload.sender.login;
+    const comment = context.payload.comment.body;
+    const issueNumber = context.payload.issue.number;
+    const issueCreatorId = context.payload.issue.user.id;
+    const htmlURL = context.payload.issue.html_url;
+
+    const isPR = htmlURL?.includes(`/pull/${issueNumber}`);
+
+    // check if comment sender is repo owner
+    // TODO; uncomment after testing
+    // if(owner !== sender) {
+    //   return;
+    // }
+    // check if comment taggged gitpoap-bot
+    if(!comment.includes("@gitpoap-bot")) {
+      return;
+    }
+    // parse followed tagged contributors
+    const tagBody = comment.split("@gitpoap-bot ")[1];
+    const contributors = tagBody?.match(/@\w*/g)?.map(ele => ele.replace("@", "")).filter(ele => ele) ?? [];
+    const uniqueContributors =  Array.from(new Set(contributors));
+    // fetch github ids
+    const contributorGithubIds: number[] = [];
+    for(let contributor of uniqueContributors) {
+      const id: number = await fetch(`https://api.github.com/users/${contributor}`).then(res => res.json()).then(res => res.id);
+      contributorGithubIds.push(id)
+    }
+    // if there is no contributors tagged, we are going to awerad GitPOAP to PR/issue creator
+    if(contributorGithubIds.length === 0) {
+      contributorGithubIds.push(issueCreatorId);
+    }
+    // create claims for these contributors via API endpoint
+    const octokit = await app.auth(); // Not passing an id returns a JWT-authenticated client
+    const jwt = (await octokit.auth({ type: 'app' })) as { token: string };
+
+    const data = isPR ? {
+      pullRequest: {
+        organization,
+        repo,
+        pullRequestNumber: issueNumber,
+        contributorGithubIds,
+        wasEarnedByMention: true
+      }
+    } : {
+      issue: {
+        organization,
+        repo,
+        issueNumber,
+        contributorGithubIds,
+        wasEarnedByMention: false
+      }
+    }
+
+    const res = await fetch(`${process.env.API_URL}/claims/gitpoap-bot/create`, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${jwt.token}`,
+      },
+      body: JSON.stringify(data),
+    });
+
+    if (res.status !== 200) {
+      context.log.error(`An issue occurred (response code: ${res.status}): ${await res.text()}`);
+      return;
+    }
+
+    // create a comment to show info about gitpoap
+    const response = await res.json();
+
+    if (response.newClaims.length === 0) {
+      context.log.info('No new claims were created by this PR');
+      return;
+    }
+
+    context.log.info(`${response.newClaims.length} new Claims were created by this PR`);
+
+    const issueComment = context.issue({
+      body: generateIssueComment(response.newClaims),
+    });
+
+    const result = await context.octokit.issues.createComment(issueComment);
+
+    context.log.info(`Posted comment about new claims: ${result.data.html_url}`);
+  });
 };

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -148,11 +148,12 @@ export default (app: Probot) => {
     }
     // check if comment taggged gitpoap-bot
     if(!comment.includes("@gitpoap-bot")) {
+      context.log.info(`Sender didn't tag @gitpoap-bot in this comment`);
       return;
     }
     // parse followed tagged contributors
     const tagBody = comment.split("@gitpoap-bot ")[1];
-    const contributors = tagBody?.match(/@\w*/g)?.map(ele => ele.replace("@", "")).filter(ele => ele) ?? [];
+    const contributors = tagBody?.match(/@\w*/g)?.map(contributor => contributor.replace("@", "")).filter(contributor => contributor) ?? [];
     const uniqueContributors =  Array.from(new Set(contributors));
     // fetch github ids
     const contributorGithubIds: number[] = [];
@@ -160,7 +161,7 @@ export default (app: Probot) => {
       const id: number = await fetch(`https://api.github.com/users/${contributor}`).then(res => res.json()).then(res => res.id);
       contributorGithubIds.push(id)
     }
-    // if there is no contributors tagged, we are going to awerad GitPOAP to PR/issue creator
+    // if there are no contributors tagged, we award GitPOAP(s) to the PR/issue creator
     if(contributorGithubIds.length === 0) {
       contributorGithubIds.push(issueCreatorId);
     }

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -102,8 +102,14 @@ export default (app: Probot) => {
     // fetch github ids
     const contributorGithubIds: number[] = [];
     for(let contributor of uniqueContributors) {
-      const id: number = await fetch(`https://api.github.com/users/${contributor}`).then(res => res.json()).then(res => res.id);
-      contributorGithubIds.push(id)
+      const res = await context.octokit.users.getByUsername({
+        username: contributor
+      });
+      const user = res.data;
+
+      if(user && user.id) {
+        contributorGithubIds.push(user?.id)
+      }
     }
     // if there are no contributors tagged, we award GitPOAP(s) to the PR/issue creator
     if(contributorGithubIds.length === 0) {

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -21,6 +21,8 @@ export default (app: Probot) => {
     const repo = context.payload.repository.name;
     const owner = context.payload.repository.owner.login;
     const pullRequestNumber = context.payload.number;
+    const senderId = context.payload.pull_request.user.id;
+    const organization = context.payload.organization?.login ?? "";
 
     context.log.info(
       `Handling newly merged PR: https://github.com/${owner}/${repo}/${pullRequestNumber}`,
@@ -45,9 +47,13 @@ export default (app: Probot) => {
         Authorization: `Bearer ${jwt.token}`,
       },
       body: JSON.stringify({
-        repo,
-        owner,
-        pullRequestNumber,
+        pullRequest: {
+          organization,
+          repo,
+          pullRequestNumber: pullRequestNumber,
+          contributorGithubIds: [senderId],
+          wasEarnedByMention: false
+        }
       }),
     });
 
@@ -133,7 +139,7 @@ export default (app: Probot) => {
         repo,
         issueNumber,
         contributorGithubIds,
-        wasEarnedByMention: false
+        wasEarnedByMention: true
       }
     }
 

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -143,10 +143,9 @@ export default (app: Probot) => {
     const isPR = htmlURL?.includes(`/pull/${issueNumber}`);
 
     // check if comment sender is repo owner
-    // TODO; uncomment after testing
-    // if(owner !== sender) {
-    //   return;
-    // }
+    if(owner !== sender) {
+      return;
+    }
     // check if comment taggged gitpoap-bot
     if(!comment.includes("@gitpoap-bot")) {
       return;

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -1,6 +1,7 @@
 import { Context, Probot } from 'probot';
 import { fetch } from 'cross-fetch';
 import * as Sentry from '@sentry/node';
+import {generateComment, generateIssueComment} from "./comments";
 
 /* @probot/pino automatically picks up SENTRY_DSN from .env */
 Sentry.init({
@@ -9,63 +10,6 @@ Sentry.init({
   enabled: process.env.NODE_ENV !== 'development',
   tracesSampleRate: 1.0,
 });
-
-// Should be the same as in gitpoap-backend/src/routes/claims.ts
-type BotClaimData = {
-  id: number;
-  gitPOAP: { id: number; poapEventId: number; threshold: number };
-  user: { githubHandle: string },
-  name: string;
-  imageUrl: string;
-  description: string;
-};
-
-function generateComment(claims: BotClaimData[]): string {
-  let qualifier: string;
-  if (claims.length > 1) {
-    qualifier = `some GitPOAPs`;
-  } else {
-    qualifier = `a GitPOAP`;
-  }
-
-  let comment = `Woohoo, your important contribution to this open-source project has earned you ${qualifier}!\n`;
-
-  for (const claim of claims) {
-    comment += `
-[**${claim.name}**](https://www.gitpoap.io/gp/${claim.gitPOAP.id}):
-<img alt="${claim.name} GitPOAP Badge" src="${claim.imageUrl}" height="200px">`;
-  }
-
-  comment +=
-    '\n\nHead on over to [GitPOAP.io](https://www.gitpoap.io) and connect your GitHub account to mint!';
-
-  return comment;
-}
-
-function generateIssueComment(claims: BotClaimData[]): string {
-  let qualifier: string;
-  if (claims.length > 1) {
-    qualifier = `some GitPOAPs`;
-  } else {
-    qualifier = `a GitPOAP`;
-  }
-
-  const receivers = claims.map(claim => claim.user.githubHandle);
-  const uniqueReceivers = Array.from(new Set(receivers));
-  const receiversTag = uniqueReceivers.reduce((acc, ele) => acc + `@${ele} `, "");
-  let comment = `Congrats, ${receiversTag}! You've earned ${qualifier} for your contribution!\n`;
-
-  for (const claim of claims) {
-    comment += `
-[**${claim.name}**](https://www.gitpoap.io/gp/${claim.gitPOAP.id}):
-<img alt="${claim.name} GitPOAP Badge" src="${claim.imageUrl}" height="200px">`;
-  }
-
-  comment +=
-    '\n\nHead on over to [GitPOAP.io](https://www.gitpoap.io) and connect your GitHub account to mint if you haven’t already!';
-
-  return comment;
-}
 
 export default (app: Probot) => {
   app.on('pull_request.closed', async (context: Context<'pull_request.closed'>) => {

--- a/src/comments.ts
+++ b/src/comments.ts
@@ -1,0 +1,56 @@
+// Should be the same as in gitpoap-backend/src/routes/claims.ts
+type BotClaimData = {
+    id: number;
+    gitPOAP: { id: number; poapEventId: number; threshold: number };
+    user: { githubHandle: string },
+    name: string;
+    imageUrl: string;
+    description: string;
+  };
+  
+export function generateComment(claims: BotClaimData[]): string {
+    let qualifier: string;
+    if (claims.length > 1) {
+      qualifier = `some GitPOAPs`;
+    } else {
+      qualifier = `a GitPOAP`;
+    }
+  
+    let comment = `Woohoo, your important contribution to this open-source project has earned you ${qualifier}!\n`;
+  
+    for (const claim of claims) {
+        comment += `
+[**${claim.name}**](https://www.gitpoap.io/gp/${claim.gitPOAP.id}):
+<img alt="${claim.name} GitPOAP Badge" src="${claim.imageUrl}" height="200px">`;
+    }
+  
+    comment +=
+      '\n\nHead on over to [GitPOAP.io](https://www.gitpoap.io) and connect your GitHub account to mint!';
+  
+    return comment;
+  }
+  
+export function generateIssueComment(claims: BotClaimData[]): string {
+    let qualifier: string;
+    if (claims.length > 1) {
+      qualifier = `some GitPOAPs`;
+    } else {
+      qualifier = `a GitPOAP`;
+    }
+  
+    const receivers = claims.map(claim => claim.user.githubHandle);
+    const uniqueReceivers = Array.from(new Set(receivers));
+    const receiversTag = uniqueReceivers.reduce((acc, receiver) => acc + `@${receiver} `, "");
+    let comment = `Congrats, ${receiversTag}! You've earned ${qualifier} for your contribution!\n`;
+  
+    for (const claim of claims) {
+      comment += `
+[**${claim.name}**](https://www.gitpoap.io/gp/${claim.gitPOAP.id}):
+<img alt="${claim.name} GitPOAP Badge" src="${claim.imageUrl}" height="200px">`;
+    }
+  
+    comment +=
+      '\n\nHead on over to [GitPOAP.io](https://www.gitpoap.io) and connect your GitHub account to mint if you haven’t already!';
+  
+    return comment;
+  }

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -4,15 +4,15 @@ const PER_PAGE = 100;
 
 function getApp() {
   return new App({
-    appId: process.env.APP_ID,
-    privateKey: process.env.PRIVATE_KEY,
+    appId: process.env.APP_ID ?? "",
+    privateKey: process.env.PRIVATE_KEY ?? "",
   });
 }
 
 export async function getBotInstalls() {
   const app = getApp();
 
-  let results = [];
+  let results: any = [];
 
   let page = 1;
   for (let count = PER_PAGE; count === PER_PAGE; ++page) {
@@ -21,7 +21,7 @@ export async function getBotInstalls() {
       per_page: PER_PAGE,
     });
     count = installations.length;
-    results = results.concat(installations.map(i => i.account.html_url));
+    results = results.concat(installations.map(i => i?.account?.html_url));
   }
 
   return results;

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -4,15 +4,15 @@ const PER_PAGE = 100;
 
 function getApp() {
   return new App({
-    appId: process.env.APP_ID ?? "",
-    privateKey: process.env.PRIVATE_KEY ?? "",
+    appId: process.env.APP_ID,
+    privateKey: process.env.PRIVATE_KEY,
   });
 }
 
 export async function getBotInstalls() {
   const app = getApp();
 
-  let results: any = [];
+  let results = [];
 
   let page = 1;
   for (let count = PER_PAGE; count === PER_PAGE; ++page) {

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -4,15 +4,15 @@ const PER_PAGE = 100;
 
 function getApp() {
   return new App({
-    appId: process.env.APP_ID,
-    privateKey: process.env.PRIVATE_KEY,
+    appId: process.env.APP_ID ?? "",
+    privateKey: process.env.PRIVATE_KEY ?? "",
   });
 }
 
 export async function getBotInstalls() {
   const app = getApp();
 
-  let results = [];
+  let results: (string | undefined)[] = [];
 
   let page = 1;
   for (let count = PER_PAGE; count === PER_PAGE; ++page) {
@@ -21,8 +21,8 @@ export async function getBotInstalls() {
       per_page: PER_PAGE,
     });
     count = installations.length;
-    results = results.concat(installations.map(i => i?.account?.html_url));
+    const htmlUrls = installations.map(i => i?.account?.html_url);
+    results = results.concat(htmlUrls);
   }
-
   return results;
 }


### PR DESCRIPTION
## WHAT'S DONE
- Handled `issue_comment.created` event on Github
- Parsed comment body if it contains `@gitpoap-bot` commented by repo owner/maintainer
- Fetched Github ids for contributors tagged in the comment
- Created GitPOAP claims through `/gitpoap-bot/create` endpoint
- After successful claims, created a comment contains GitPOAP claim link
- Updated payload for `/gitpoap-bot/create` in pull_request.closed

## NOTE
- For this bot to work properly, we need to ask `Issue comment` permission additionally