### PR TITLE
fix: remove breadcrumb limit

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -10,7 +10,6 @@ Sentry.init({
   enabled: process.env.NODE_ENV !== 'development',
   tracesSampleRate: 1.0,
   attachStacktrace: true,
-  maxBreadcrumbs: 10,
   maxValueLength: 500,
 });
 


### PR DESCRIPTION
Summary:
Remove Breadcrumb limit that was erroneously set to below the default. We want more data not less. 